### PR TITLE
feat: Staggered scheduling strategy

### DIFF
--- a/app.json
+++ b/app.json
@@ -61,12 +61,14 @@
         {
             "matchDatasources":["docker"],
             "addLabels":["docker"],
-            "reviewers":["team:sre"]
+            "reviewers":["team:sre"],
+            "schedule": ["before 2am", "after 11pm"]
         },
         {
             "matchDatasources":["github-actions"],
             "addLabels":["github"],
-            "reviewers":["team:sre"]
+            "reviewers":["team:sre"],
+            "schedule": ["before 3am", "after 10pm"]
         },
         {
             "matchPackagePatterns":["elasticsearch"],
@@ -92,11 +94,13 @@
         {
             "matchDatasources":["helm"],
             "addLabels":["helm"],
-            "reviewers":["team:sre"]
+            "reviewers":["team:sre"],
+            "schedule": ["before 4am", "after 9pm"]
         },
         {
             "matchDatasources":["github-releases"],
-            "reviewers":["team:sre"]
+            "reviewers":["team:sre"],
+            "schedule": ["before 5am", "after 8pm"]
         }
     ]
 }

--- a/base.json
+++ b/base.json
@@ -5,6 +5,10 @@
     "rebaseWhen": "conflicted",
     "labels": ["renovate"],
     "onboardingConfigFileName": ".github/renovate.json",
+    "prConcurrentLimit": 2,
+    "prHourlyLimit": 4,
+    "schedule": ["before 6am", "after 10pm"],
+    "timezone": "Europe/Vilnius",
     "dockerfile":{
         "fileMatch":[
             "^Makefile$"

--- a/base.json
+++ b/base.json
@@ -8,7 +8,7 @@
     "prConcurrentLimit": 2,
     "prHourlyLimit": 4,
     "schedule": ["before 6am", "after 10pm"],
-    "timezone": "Europe/Vilnius",
+    "timezone": "UTC",
     "dockerfile":{
         "fileMatch":[
             "^Makefile$"

--- a/flux.json
+++ b/flux.json
@@ -83,7 +83,8 @@
             "separateMinorPatch":true,
             "ignoreDeprecated":true,
             "additionalBranchPrefix":"{{#if (containsString packageFileDir 'clusters/staging')}}staging{{else}}{{#if (containsString packageFileDir 'clusters/dev')}}dev{{else}}{{#if (containsString packageFileDir 'clusters/prod')}}prod{{else}}{{#if (containsString packageFileDir 'base/')}}base{{/if}}{{/if}}{{/if}}{{/if}}-",
-            "addLabels":["helm", "{{#if (containsString packageFileDir 'clusters/staging')}}staging{{/if}}", "{{#if (containsString packageFileDir 'clusters/dev')}}dev{{/if}}", "{{#if (containsString packageFileDir 'clusters/prod')}}prod{{/if}}", "{{#if (containsString packageFileDir 'base/')}}base{{/if}}"]
+            "addLabels":["helm", "{{#if (containsString packageFileDir 'clusters/staging')}}staging{{/if}}", "{{#if (containsString packageFileDir 'clusters/dev')}}dev{{/if}}", "{{#if (containsString packageFileDir 'clusters/prod')}}prod{{/if}}", "{{#if (containsString packageFileDir 'base/')}}base{{/if}}"],
+            "schedule": ["before 1am", "after 11pm"]
         },
         {
             "matchDatasources":[
@@ -92,13 +93,15 @@
             "separateMinorPatch":true,
             "ignoreDeprecated":true,
             "additionalBranchPrefix":"{{#if (containsString packageFileDir 'clusters/staging')}}staging{{else}}{{#if (containsString packageFileDir 'clusters/dev')}}dev{{else}}{{#if (containsString packageFileDir 'clusters/prod')}}prod{{else}}{{#if (containsString packageFileDir 'base/')}}base{{/if}}{{/if}}{{/if}}{{/if}}-",
-            "addLabels":["docker", "{{#if (containsString packageFileDir 'clusters/staging')}}staging{{/if}}", "{{#if (containsString packageFileDir 'clusters/dev')}}dev{{/if}}", "{{#if (containsString packageFileDir 'clusters/prod')}}prod{{/if}}", "{{#if (containsString packageFileDir 'base/')}}base{{/if}}"]
+            "addLabels":["docker", "{{#if (containsString packageFileDir 'clusters/staging')}}staging{{/if}}", "{{#if (containsString packageFileDir 'clusters/dev')}}dev{{/if}}", "{{#if (containsString packageFileDir 'clusters/prod')}}prod{{/if}}", "{{#if (containsString packageFileDir 'base/')}}base{{/if}}"],
+            "schedule": ["before 2am", "after 10pm"]
         },
         {
             "matchPackagePatterns":[
                 "^victoriametrics"
             ],
-            "additionalBranchPrefix":"{{#if (containsString packageFileDir 'clusters/staging')}}staging{{else}}{{#if (containsString packageFileDir 'clusters/dev')}}dev{{else}}{{#if (containsString packageFileDir 'clusters/prod')}}prod{{else}}{{#if (containsString packageFileDir 'base/')}}base{{/if}}{{/if}}{{/if}}{{/if}}-"
+            "additionalBranchPrefix":"{{#if (containsString packageFileDir 'clusters/staging')}}staging{{else}}{{#if (containsString packageFileDir 'clusters/dev')}}dev{{else}}{{#if (containsString packageFileDir 'clusters/prod')}}prod{{else}}{{#if (containsString packageFileDir 'base/')}}base{{/if}}{{/if}}{{/if}}{{/if}}-",
+            "schedule": ["before 3am", "after 9pm"]
         },
         {
             "groupName": "app-template patch dependencies",
@@ -108,7 +111,8 @@
             ],
             "matchUpdateTypes": [
               "patch"
-            ]
+            ],
+            "schedule": ["before 4am", "after 8pm"]
         },
         {
             "groupName": "app-template minor dependencies",
@@ -118,7 +122,8 @@
             ],
             "matchUpdateTypes": [
               "minor"
-            ]
+            ],
+            "schedule": ["before 5am", "after 7pm"]
         }
     ]
 }


### PR DESCRIPTION
https://linear.app/mailerlite/issue/SRE-9119/reconfigure-renovate-to-avoid-rate-limits

Global changes:
- prConcurrentLimit: 2 - Limits concurrent PRs to 2 at a time
- prHourlyLimit: 4 - Limits PR creation to 4 per hour
- Global schedule - ["before 6am", "after 10pm"] to run during off-peak hours
- Timezone - Set to Europe/Vilnius for proper scheduling

I've also implemented a staggered approach where different package types run at different times:
In app.json:
- Docker packages: before 2am, after 11pm
- GitHub Actions: before 3am, after 10pm
- Helm packages: before 4am, after 9pm
- GitHub Releases: before 5am, after 8pm
- Groot package: kept existing scheduling due to highest priority

In flux.json:
- Helm packages: before 1am, after 11pm
- Docker packages: before 2am, after 10pm
- VictoriaMetrics: before 3am, after 9pm
- App-template patch: before 4am, after 8pm
- App-template minor: before 5am, after 7pm
