### PR TITLE
feat: set automerge rules better and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Packages are classified as **internal** or **external** based on their origin.
 | Docker | `europe-docker.pkg.dev/mailerlite-gcp/` |
 | Docker | `europe-docker.pkg.dev/mailercheck-usa/` |
 | Docker | `europe-docker.pkg.dev/mailersend-214215/` |
+| Docker | `europe-docker.pkg.dev/mailerlite-v2/` |
 | GitHub Actions / Releases | `mailerlite/*`, `mailersend/*`, `mailercheck/*` |
 
 Internal packages:
@@ -130,19 +131,21 @@ For Kubernetes Flux cluster repositories. Managers:
 | `custom.regex` | Annotated versions in cluster YAML |
 | `custom.jsonata` | app-template `image` fields (repository/tag/digest) |
 
-**Environment awareness:** PRs are labelled and branch-prefixed by environment based on file path (`clusters/dev/`, `clusters/staging/`, `clusters/prod/`). Minor and patch updates are tracked separately.
+**Environment awareness:** PRs are labelled and branch-prefixed by environment based on file path (`clusters/dev/`, `clusters/staging/`, `clusters/prod/`, `clusters/production/`). Minor and patch updates are split into separate PRs by default, except for internal Docker images in dev/staging where both auto-merge so the split adds no value.
 
 **Digest pinning:** Internal Docker images in Flux cluster files **are** digest-pinned (unlike in app repos). This ensures cluster deployments are fully deterministic. The `flux` manager itself has digest pinning disabled because the inline `tag@digest` format is not valid in HelmRelease values — digest tracking is handled by the custom managers instead.
 
-**Auto-merge** (dev and staging environments only):
+**Auto-merge:** PRs that auto-merge receive an `automerge` label.
 
 | Update type | dev / staging | prod |
 |-------------|--------------|------|
-| Internal Docker patch | Auto-merge (CI required) | PR only |
-| Internal Docker minor | Auto-merge (CI required) | PR only |
-| Internal Docker pinDigest | Auto-merge (CI required) | PR only |
+| Internal Docker patch | Auto-merge (CI required) | Auto-merge (CI required) |
+| Internal Docker minor | Auto-merge (CI required) | Auto-merge, 1 day buffer (CI required) |
+| Internal Docker pinDigest | Auto-merge (CI required) | Auto-merge (CI required) |
 | Internal Docker major | PR only | PR only |
 | External | PR only | PR only |
+
+The 1-day buffer on prod minor means by the time the PR is created, the change has already been running in dev/staging for at least a day via webhook — it acts as a natural soak gate.
 
 Internal GHA patch and minor updates auto-merge across all repos (including Flux).
 

--- a/base.json
+++ b/base.json
@@ -58,7 +58,7 @@
             "matchManagers": ["github-actions"],
             "matchPackagePatterns": ["^(mailerlite|mailersend|mailercheck)/"],
             "matchUpdateTypes": ["patch", "minor"],
-            "addLabels": ["automerge_test"]
+            "addLabels": ["automerge_test", "automerge"]
         },
         {
             "description": "Group digest-only pins into a single PR - no version changes",

--- a/flux.json
+++ b/flux.json
@@ -111,12 +111,19 @@
             "pinDigests": false
         },
         {
-            "description": "Helm and Docker - split by environment, separate minor/patch",
+            "description": "Helm and Docker - split by environment, separate minor/patch by default",
             "matchDatasources": ["helm", "docker"],
             "separateMinorPatch": true,
             "ignoreDeprecated": true,
             "additionalBranchPrefix": "{{#if (containsString packageFileDir 'clusters/staging')}}staging{{else}}{{#if (containsString packageFileDir 'clusters/dev')}}dev{{else}}{{#if (containsString packageFileDir 'clusters/prod')}}prod{{else}}{{#if (containsString packageFileDir 'base/')}}base{{/if}}{{/if}}{{/if}}{{/if}}-",
             "addLabels": ["{{#if (containsString packageFileDir 'clusters/staging')}}staging{{/if}}", "{{#if (containsString packageFileDir 'clusters/dev')}}dev{{/if}}", "{{#if (containsString packageFileDir 'clusters/prod')}}prod{{/if}}", "{{#if (containsString packageFileDir 'base/')}}base{{/if}}"]
+        },
+        {
+            "description": "Internal Docker in dev/staging - no minor/patch split, both automerge so separation adds noise",
+            "matchPackagePatterns": ["docker\\.pkg\\.dev/(mailerlitehub|mailerlite-gcp|mailercheck-usa|mailersend-214215|mailerlite-v2)/"],
+            "matchDatasources": ["docker"],
+            "matchFileNames": ["**/clusters/dev/**", "**/clusters/staging/**"],
+            "separateMinorPatch": false
         },
         {
             "description": "Helm charts label",
@@ -152,7 +159,25 @@
             "matchPackagePatterns": ["docker\\.pkg\\.dev/(mailerlitehub|mailerlite-gcp|mailercheck-usa|mailersend-214215|mailerlite-v2)/"],
             "matchUpdateTypes": ["patch", "minor", "pinDigest"],
             "matchFileNames": ["**/clusters/dev/**", "**/clusters/staging/**"],
-            "automerge": true
+            "automerge": true,
+            "addLabels": ["automerge"]
+        },
+        {
+            "description": "Auto-merge internal Docker patch/pinDigest in prod",
+            "matchPackagePatterns": ["docker\\.pkg\\.dev/(mailerlitehub|mailerlite-gcp|mailercheck-usa|mailersend-214215|mailerlite-v2)/"],
+            "matchUpdateTypes": ["patch", "pinDigest"],
+            "matchFileNames": ["**/clusters/prod/**", "**/clusters/production/**"],
+            "automerge": false,
+            "addLabels": ["automerge", "automerge_test"]
+        },
+        {
+            "description": "Auto-merge internal Docker minor in prod - 1 day buffer as soak gate",
+            "matchPackagePatterns": ["docker\\.pkg\\.dev/(mailerlitehub|mailerlite-gcp|mailercheck-usa|mailersend-214215|mailerlite-v2)/"],
+            "matchUpdateTypes": ["minor"],
+            "matchFileNames": ["**/clusters/prod/**", "**/clusters/production/**"],
+            "minimumReleaseAge": "1 day",
+            "automerge": false,
+            "addLabels": ["automerge", "automerge_test"]
         }
     ]
 }


### PR DESCRIPTION
- Updating docs
- adding more rules so automerge in prod happens for patch, 1-day buffer for dev
- add `automerge` label to all automerged PRs so easy to check
- merge `patch` and `minor` PRs for internal dev packages since they are getting automerged regardless
- still in testing stages for prod